### PR TITLE
Change email regex

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     strict: 0,
     'linebreak-style': ['error', 'unix'],
+    'max-len': 'off',
   },
   extends: ['google']
 };

--- a/src/rule/email.js
+++ b/src/rule/email.js
@@ -14,7 +14,7 @@ export default (msg) => (value) => {
   if (tc.isNullOrUndefined(value) || tc.not.isString(value)) {
     return msg;
   }
-  const rule = /^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/;
+  const rule = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/g;
   if (value.match(rule) == null) {
     return msg;
   }

--- a/src/rule/index.test.js
+++ b/src/rule/index.test.js
@@ -56,6 +56,7 @@ describe('Email', () => {
     {cond: 'email@domaincom', res: 'invalid'},
     {cond: '@domain.com', res: 'invalid'},
     {cond: 'email@domain.com', res: true},
+    {cond: 'email@domain.longertld', res: true},
   ];
   runTests(email('invalid'), tests);
 });


### PR DESCRIPTION
I changed the regex that checks email addresses to one that meets RFC 5322 standards. Additionally, I added a test for checking email addresses with a longer TLD and turned off the line width limitation so as not to split the regex.